### PR TITLE
Change to more reliable invocation of modals.

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,7 +7,7 @@
 
     <!-- Bootstrap -->
     <link rel="stylesheet" href="/libs/css/bootstrap/bootstrap-3.3.7-dist/css/bootstrap.min.css" />
-   <link href="/libs/css/bootstrap/bootstrap-3.3.7-dist/flatly/bootstrap.min.css" rel="stylesheet" />-->
+   <link href="/libs/css/bootstrap/bootstrap-3.3.7-dist/flatly/bootstrap.min.css" rel="stylesheet" />
 
     <!-- jQuery daterangepicker, jQuery timepicker, & Dragula -->
     <link href="./dependencies/jquery-daterange-picker/daterangepicker.min.css" rel="stylesheet" />
@@ -34,27 +34,27 @@
           </a>
           <ul class="dropdown-menu">
             <li id="openMenu">
-              <a href="javascript:location.reload()" class="topNavItem">
+              <a onclick="javascript:location.reload()" class="topNavItem">
                 Open
               </a>
             </li>
             <li id="editMetadataMenu">
-              <a href="javascript:showEditMetadata();" class="topNavItem">
+              <a onclick="showEditMetadata();" class="topNavItem">
                 Edit dates and name
               </a>
             </li>
             <li id="saveMenu">
-              <a href="javascript:saveProgram();" class="topNavItem">
+              <a onclick="saveProgram();" class="topNavItem">
                 Save
               </a>
             </li>
             <li id="saveAsMenu">
-              <a href="javascript:saveAs();" class="topNavItem">
+              <a onclick="saveAs();" class="topNavItem">
                 Save a copy...
               </a>
             </li>
             <li id="deleteMenu">
-              <a href="javascript:showDeleteProgram();" class="topNavItem">
+              <a onclick="showDeleteProgram();" class="topNavItem">
                 Delete from server
               </a>
             </li>
@@ -66,12 +66,12 @@
           </a>
           <ul class="dropdown-menu">
             <li id="downloadMenu">
-              <a href="javascript:downloadJSON()" class="topNavItem">
+              <a onclick="downloadJSON()" class="topNavItem">
                 Download JSON for website
               </a>
             </li>
             <li id="downloadPDFMenu">
-              <a href="javascript:showPDFDownload()" class="topNavItem">
+              <a onclick="showPDFDownload()" class="topNavItem">
                 Download PDF for printing
               </a>
             </li>
@@ -83,17 +83,17 @@
           </a>
           <ul class="dropdown-menu">
             <li id="importTalksMenu">
-              <a href="javascript:showImportFSEorCHES(true)" class="topNavItem">
+              <a onclick="showImportFSEorCHES(true)" class="topNavItem">
                 Import papers from TCHES or ToSC
               </a>
             </li>
             <li id="uploadTalksMenu">
-              <a href="javascript:showWebsubrevUpload(true)" class="topNavItem">
+              <a onclick="showWebsubrevUpload(true)" class="topNavItem">
                 Upload papers in websubrev format
               </a>
             </li>
             <li id="importDOIMenu">
-              <a href="javascript:startImportDOIs()" class="topNavItem">
+              <a onclick="startImportDOIs()" class="topNavItem">
                 Import paper URLs
               </a>
             </li>
@@ -117,12 +117,12 @@
           <ul class="dropdown-menu">
             <li><span class="dropdownText" id="login_status">Login status unknown</span></li>
             <li id="loginMenu">
-              <a href="#" onClick="$('#authModal').modal();this.blur()" class="topNavItem">
+              <a onClick="$('#authModal').modal();this.blur()" class="topNavItem">
                 Log in
               </a>
             </li>
             <li id="logoutMenu">
-              <a href="javascript:doLogout()" class="topNavItem">Log out</a>
+              <a onclick="doLogout()" class="topNavItem">Log out</a>
             </li>
           </ul>
         </li>
@@ -280,7 +280,7 @@
             <h3 class="text-center editorTitles">
               Unscheduled Talks
               <label data-toggle="tooltip" title="Add a talk" data-placement="top" data-trigger="hover" tabindex="0">
-                <button type="button" name="addTalk" class="btn btn-success" id="addTalkBtn" data-toggle="modal" data-target="#editTalkBox" onclick="showTalkEditor('')">
+                <button type="button" name="addTalk" class="btn btn-success" id="addTalkBtn" onclick="showTalkEditor('')">
                   <span class="glyphicon glyphicon-plus" aria-hidden="true"></span>
                 </button>
               </label>
@@ -301,7 +301,7 @@
         <!-- This is a handlebars partial that can be used in two places to display a talk. -->
         <script id="talk-partial" type="text/x-handlebars-template">
           <div class="talk" id="{{id}}">
-            <a data-toggle="modal" data-target="#editTalkBox" href="#editTalk" class="pull-right" onclick="showTalkEditor('{{id}}');">
+            <a class="pull-right" onclick="showTalkEditor('{{id}}');">
               <label data-toggle="tooltip" title="Edit the talk" data-placement="top" data-trigger="hover" tabindex="0">
                 <span class="glyphicon glyphicon-pencil" aria-hidden="true"></span>
               </label>
@@ -329,7 +329,7 @@
             {{#each unassigned_talks}}
               <div id="{{id}}">
                 <div class="categoryDiv">
-                <a data-toggle="modal" data-target="#editCategoryBox" href="#editCategory" class="pull-right" onclick="showCategoryEditor('{{id}}');">
+                <a class="pull-right" onclick="showCategoryEditor('{{id}}');">
                   <label data-toggle="tooltip" title="Edit the category" data-placement="bottom" data-trigger="hover" tabindex="0">
                     <span class="glyphicon glyphicon-pencil" aria-hidden="true"></span>
                   </label>
@@ -348,7 +348,7 @@
           </script>
           </section>
           <label data-toggle="tooltip" title="Add a Category. These are not used in the program itself." data-placement="top" data-trigger="hover" tabindex="0" z-index="2" id="newCategoryButton">
-            <button type="button" name="addCategory" class="btn btn-success pull-right" id="addCategoryBtn" data-toggle="modal" data-target="#editCategoryBox" onclick="showCategoryEditor('')">
+            <button type="button" name="addCategory" class="btn btn-success pull-right" id="addCategoryBtn" onclick="showCategoryEditor('')">
               <span class="glyphicon glyphicon-plus" aria-hidden="true"></span>
             </button>
           </label>
@@ -362,7 +362,7 @@
                   <hr />
                   <h3 class="pageSubtitle">
                     {{formatDate date}} <label data-toggle="tooltip" title="Add a time slot" data-placement="top" data-trigger="hover" tabindex="0">
-                      <button type="button" name="addTimeslot" class="addTimeslot btn btn-success" data-toggle="modal" data-target="#addTimeslot" onclick="prepareAddTimeslotToDay({{@index}})">
+                      <button type="button" name="addTimeslot" class="addTimeslot btn btn-success" onclick="prepareAddTimeslotToDay({{@index}})">
                         <span class="glyphicon glyphicon-plus" aria-hidden="true"></span>
                       </button>
                     </label>
@@ -373,7 +373,7 @@
               {{#if sessions}} <!-- only render slots that have sessions -->
               <div class="row">
                 <div class="col-md-2 timeSlotDiv">
-                    <a data-toggle="modal" href="#editTimeslot" class="pull-right" onclick="editTimeslot({{@../index}}, {{@index}})">
+                    <a class="pull-right" onclick="editTimeslot({{@../index}}, {{@index}})">
                       <label data-toggle="tooltip" title="Edit the time slot" data-placement="top" data-trigger="hover" tabindex="0">
                         <span class="glyphicon glyphicon-pencil" aria-hidden="true"></span>
                       </label>
@@ -385,7 +385,7 @@
                 </div>
                 <div class="{{#if twosessions}}col-md-5{{else}}col-md-10{{/if}}">
                   <div class="{{#if twosessions}}track1Event{{else}}mutualEvent{{/if}} panel-body" id="{{sessions.0.id}}">
-                    <a data-toggle="modal" href="#editSessionBox" class="pull-right" onclick="editSession({{@../index}},{{@index}},0)">
+                    <a class="pull-right" onclick="editSession({{@../index}},{{@index}},0)">
                       <label data-toggle="tooltip" title="Edit the session" data-placement="top" data-trigger="hover" tabindex="0">
                         <span class="glyphicon glyphicon-pencil" aria-hidden="true"></span>
                       </label>
@@ -415,7 +415,7 @@
                 {{#if twosessions}}
                 <div class="col-md-5">
                   <div class="panel-body track2Event" id="{{sessions.1.id}}">
-                    <a data-toggle="modal" href="#editSessionBox" class="pull-right" onclick="editSession({{@../index}},{{@index}},1)">
+                    <a class="pull-right" onclick="editSession({{@../index}},{{@index}},1)">
                       <label data-toggle="tooltip" title="Edit the session" data-placement="top" data-trigger="hover" tabindex="0">
                         <span class="glyphicon glyphicon-pencil" aria-hidden="true"></span>
                       </label>

--- a/scripts/editor.js
+++ b/scripts/editor.js
@@ -100,7 +100,6 @@ function showEditMetadata() {
   document.getElementById('deleteDayOption').selectedIndex = 0;
   $('#editMetadataModal').modal();
   updateNewDates();
-  return true;
 }
 
 function reallyDeleteProgram() {
@@ -142,8 +141,11 @@ function saveAs() {
   if (progData.hasOwnProperty('database_id')) {
     delete progData.database_id;
   }
-  progData.name = 'Copy of ' + progData.name;
-  saveProgram();
+  var newName = prompt("Enter a name for new copy", "Copy of " + progData.name);
+  if (newName !== null) {
+    progData.name = newName;
+    saveProgram();
+  }
 }
 
 function currentTime() {
@@ -892,6 +894,7 @@ function showTalkEditor(id) {
   }
   $('#talkId').val(id);
 
+  var defaultTime = '11:30';
   if (id === "") { // then we're adding a new talk.
     $('#talkDeleteButton').hide();
     $('#newTalkTitle').val('');
@@ -904,17 +907,24 @@ function showTalkEditor(id) {
   } else {
     $('#talkDeleteButton').show();
     var talkObj = findObj(id, progData);
+    if (talkObj.starttime) {
+      defaultTime = talkObj.starttime;
+    }
     $('#newTalkTitle').val(talkObj.title);
     $('#newTalkAuthor').val(talkObj.authors.join(' and '))
     $('#newTalkAffiliation').val(talkObj.affiliations);
     $('#addTalkTitle').text('Edit a talk');
     $('#paperUrl').val(talkObj.paperUrl);
-    $('#currentTalkStartTime').val(talkObj.starttime);
-    $('#currentTalkEndTime').val(talkObj.endtime);
-  }
-  var defaultTime = talkObj.starttime;
-  if (!defaultTime) {
-    defaultTime = '11:30';
+    if (talkObj.starttime) {
+      $('#currentTalkStartTime').val(talkObj.starttime);
+    } else {
+      $('#currentTalkStartTime').val('');
+    }
+    if (talkObj.endtime) {
+      $('#currentTalkEndTime').val(talkObj.endtime);
+    } else {
+      $('#currentTalkEndTime').val('');
+    }
   }
   $('#talkTimeDiv .time').timepicker({
     'forceRoundTime': true,
@@ -926,6 +936,7 @@ function showTalkEditor(id) {
     'step': 5,
     'timeFormat': 'G:i'
   });
+  $('#editTalkBox').modal();
 }
 
 // Save a category. This may come from an edit on an existing category or a new
@@ -972,6 +983,7 @@ function showCategoryEditor(id) {
     var categoryObj = findObj(id, progData);
     $('#newCategoryName').val(categoryObj.name);
   }
+  $('#editCategoryBox').modal();
 }
 
 function deleteCategory() {
@@ -1040,6 +1052,7 @@ function editSession(dayIndex, slotIndex, sessionIndex) {
   }
 
   $('#allowTalks').prop('checked', sessionObj.hasOwnProperty('talks'));
+  $('#editSessionBox').modal();
 }
 
 // Function to add a timeslot to a day. This will be called to populate
@@ -1064,6 +1077,7 @@ function prepareAddTimeslotToDay(dayIndex) {
   });
   var getTimeDiv = document.getElementById('timeslotDiv');
   var timeSlotInputs = new Datepair(getTimeDiv);
+  $('#addTimeslot').modal();
 }
 
 // Simple utility function to convert HH:MM to just minutes. In other
@@ -1163,6 +1177,7 @@ function editTimeslot(dayIndex, slotIndex) {
 
   var getTimeDiv = document.getElementById('timeDiv');
   var timeSlotInputs = new Datepair(getTimeDiv);
+  $('#editTimeslot').modal();
 }
 
 // Sort the timeslots by starttime. This is called when a new timeslot


### PR DESCRIPTION
There is some inconsistency in the way that we invoked modals from <a> tags. There are three ways to do it:
1. via an href that invokes javascript.
2. via an onclick that invokes javascript.
3. using classes data-toggle="modal" and data-target="#idOfModal", which causes bootstrap.js to assign bootstrap events of some sort.

Method 3 is best suited to static modals. The use of $('#idOfModal').modal() is the bootstrap way of showing a modal in javascript, so I have put this at the end of all functions that populate a modal. I have now switched it so that every click on an <a> tag is triggered by onclick and there is no href to confuse the browser with another action on the click.