### PR TITLE
Fix for CORS issue contacting api.crossref.org.

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -1,0 +1,2 @@
+Header set Access-Control-Allow-Origin "https://api.crossref.org"
+


### PR DESCRIPTION
This fixes part of issue #159 by fixing the CORS issue. The solution is to add a .htaccess file that authorizes the offsite ajax request to crossref.org. There are at least two additional problems in that single issue.