### PR TITLE
Bootstrap4 migration

### DIFF
--- a/index.html
+++ b/index.html
@@ -931,29 +931,19 @@
               <!-- NOTE: used only for saving edited time slot to progData -->
               <input type="hidden" id="timeslotDayIndex" value="" />
               <input type="hidden" id="timeslotIndex" value="" />
-              <div class="form-inline">
-                <div class="form-group">
-                  <label for="startTime">
-                    Start time
-                  </label>
-                  to
-                  <label for="endTime">
-                    End time
-                  </label>
-                </div>
-                <div class="form-group" id="timeDiv">
-                  <input type="text" name="startTime" class="form-control time start" id="currentStartTime" autocomplete="off" />
-                  to
-                  <input type="text" name="endTime" class="form-control time end" id="currentEndTime" autocomplete="off" />
+              <div class="form">
+                <label for="startTime">Start time</label> to <label for="endTime">End time</label>
+                <div class="form-group form-inline mb-5" id="timeDiv">
+                  <input type="text" name="startTime" class="form-control time start mr-2" id="currentStartTime" autocomplete="off" /> to <input type="text" name="endTime" class="form-control time end ml-2" id="currentEndTime" autocomplete="off" />
                 </div>
                 <div id="addTrackToSession">
-                  <br />
-                  <br />
-                  <p class="form-text">
+                  <p class="form-text mb-2">
                     To split this session into two tracks, please check the box below.
                   </p>
-                  <label for="numsessions">Add a track to this timeslot?</label>
-                  <input type="checkbox" name="numsessions" id="makeDualSession"></input>
+                  <div class="form-check">
+                    <input type="checkbox" name="numsessions" id="makeDualSession" class="form-check-input"></input>
+                    <label for="numsessions" class="form-check-label">Add a track to this timeslot?</label>
+                  </div>
                 </div>
               </div>
             </form>

--- a/index.html
+++ b/index.html
@@ -995,6 +995,9 @@
                   Information URL
                 </label>
                 <input type="url" name="currentSessionURL" placeholder="Optional URL for session information" class="form-control" id="currentSessionURL"/>
+                <small class="form-text">
+                  For example, a map or website for the location or session that is not specific to a talk.
+                </small>
               </div>
               <div class="form-group">
                 <label for="currentSessionLocation">
@@ -1008,9 +1011,10 @@
                 </label>
                 <input type="text" name="currentSessionModerator" placeholder="Optional session moderator (e.g. 'Chair: Alan Turing')" class="form-control" id="currentSessionModerator" />
               </div>
-              <div class="form-group">
-                <label class="checkbox-inline" for="allowTalks">
-                  <input type="checkbox" name="allowTalks" id="allowTalks"> Allow talks in this session
+              <div class="form-check">
+                <input type="checkbox" name="allowTalks" id="allowTalks" class="form-check-input">
+                <label class="form-check-label" for="allowTalks">
+                  Allow talks in this session?
                 </label>
               </div>
             </form>


### PR DESCRIPTION
Fixes and edits for the edit time slot and edit session modals. One question I encountered was on line 934, why is the div.form instead of a form element. Seemed kinda weird but I didn't change it. Screenshots of each modal attached. 
![Screen Shot 2019-10-18 at 10 14 23](https://user-images.githubusercontent.com/13421544/67114897-c6d65d00-f191-11e9-8693-de961aa96fa1.png)
![Screen Shot 2019-10-18 at 10 22 39](https://user-images.githubusercontent.com/13421544/67114898-c6d65d00-f191-11e9-9650-67678ea2d276.png)

