### PR TITLE
Fix for CORS and error handling on DOI lookups.

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -1,2 +1,0 @@
-Header set Access-Control-Allow-Origin "https://api.crossref.org"
-

--- a/index.html
+++ b/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+    <meta http-equiv="Content-Security-Policy" content="connect-src 'self' https://api.crossref.org/";default-src: 'self'>
     <meta charset="utf-8">
 
     <title>Program Editor</title>
@@ -605,7 +606,8 @@
               Note that if Springer has not finished processing the papers for this conference, then they will not be available yet. You can always enter URLs individually at any time.
             </p>
             <div class="progress form-group">
-              <div id="doiProgress" class="progress-bar bg-success" role="progressbar" aria-valuenow="0" aria-valuemin="0" aria-valuemax="100" style="width: 0%;">0%</div>
+              <div id="doiSuccess" class="progress-bar bg-success" role="progressbar" aria-valuenow="0" aria-valuemin="0" aria-valuemax="100" style="width: 0%;">0%</div>
+              <div id="doiFailure" class="progress-bar bg-danger" role="progressbar" aria-valuenow="0" area-valuemin="0" aria-valuemax="100" style="width: 0%;">0%</div>
             </div>
           </div>
           <div class="modal-footer">

--- a/scripts/editor.js
+++ b/scripts/editor.js
@@ -1461,9 +1461,11 @@ function startImportDOIs() {
 // Construct the URL to look up a talk in crossref. We use only the
 // first author.
 function getTalkUrl(talk) {
-  var url = "https://api.crossref.org/works?rows=20&query.title=";
-  url += talk.title.replace(' ', '+');
-  url += '&query.author=' + talk.authors[0].replace(' ', '+');
+  var url = "https://api.crossref.org/works?mailto=crossref@iacr.org&rows=20&query.bibliographic=";
+  // There is a weird error that if AND in caps occurs in the title, it gets
+  // a parse error. See https://gitlab.com/crossref/issues/issues/502
+  url += encodeURIComponent(talk.title); // .replace(' AND', ' and'));
+  url += '&query.author=' + encodeURIComponent(talk.authors[0]);
   return url;
 }
 
@@ -1483,14 +1485,19 @@ function matchDOI(data, textStatus, jqXHR) {
         jqXHR.talk.authors.length == item.author.length) {
       jqXHR.talk.paperUrl = item.URL;
       return true;
-    } else {
-      console.log(i + ':' + distance + ':' + item.title[0]);
     }
   }
   return false;
 }
 
-// This class updates a boostrap progress bar with a given id.
+// This class updates a boostrap progress bar with a given id. It keeps track
+// of several counters:
+//  successCount (how many were successfully matched to a paper)
+//  errorCount (how many lookups failed because of a server error).
+//  failureCount (how many matches failed to find an answer (either from a lack of match
+//     or a server error)
+//            
+//  It finishes when successCount + failureCount = totalCount
 function ProgressMonitor(totalCount) {
   if (totalCount == 0) {
     $('#doiStatus').text('No talks to look up');
@@ -1498,21 +1505,31 @@ function ProgressMonitor(totalCount) {
     $('#doiStatus').text('');
   }
   $('.progress').show();
-  $('#doiProgress').show();
-  $('#doiProgress').css('width', '0%');
-  $('#doiProgress').prop('aria-valuenow', 0);
-  $('#doiProgress').prop('aria-valuemax', 100);
+  $('#doiSuccess').css('width', '0%');
+  $('#doiFailure').css('width', '0%');
+  $('#doiSuccess').prop('aria-valuenow', 0);
+  $('#doiFailure').prop('aria-valuenow', 0);
   this.totalCount = totalCount;
   this.failureCount = 0;
   this.successCount = 0;
+  // Errors are different than match failures. This indicates that
+  // the ajax request had a failure.
+  this.errorCount = 0;
   this.updateWidget = function() {
     var msg = this.successCount + ' found out of ' + this.totalCount;
-    var val = Math.floor(100 * (this.successCount + this.failureCount) / this.totalCount);
-    $('#doiProgress').prop('aria-valuenow', val);
-    $('#doiProgress').css('width', String(val) + '%');
-    $('#doiProgress').html(val + '%');
+    var successVal = Math.floor(100 * this.successCount / this.totalCount);
+    var failureVal = Math.floor(100 * this.failureCount / this.totalCount);
+    $('#doiSuccess').prop('aria-valuenow', successVal);
+    $('#doiSuccess').css('width', String(successVal) + '%');
+    $('#doiSuccess').html(successVal + '%');
+    $('#doiFailure').prop('aria-valuenow', failureVal);
+    $('#doiFailure').css('width', String(failureVal) + '%');
+    $('#doiFailure').html(failureVal + '%');
     if (this.totalCount == this.failureCount + this.successCount) {
       msg = 'Finished! ' + msg;
+      if (this.errorCount) {
+        msg = msg + ' (' + this.errorCount + ' had server error(s))';
+      }
     }
     $('#doiStatus').text(msg);
   }
@@ -1521,7 +1538,13 @@ function ProgressMonitor(totalCount) {
     this.updateWidget();
   }
   this.reportFailure = function() {
+    console.log('failure reported');
     this.failureCount++;
+    this.updateWidget();
+  }
+  this.reportError = function(jqXHR) {
+    this.failureCount++;
+    this.errorCount++;
     this.updateWidget();
   }
 }
@@ -1575,8 +1598,14 @@ function findDOIs() {
           progressMonitor.reportFailure();
         }
       },
-      fail: function(jqXHR, textStatus, errorThrown) {
-        progressMonitor.reportFailure();
+      error: function(jqXHR, textStatus, errorThrown) {
+        // Note that this is not called on off-domain ajax.
+        // For this purpose we need to register a global handler
+        // for ajax requests.
+        console.dir(jqXHR);
+        console.log(textStatus);
+        console.log(errorThrown);
+        progressMonitor.reportError();
       }
     });
   })).always(function() {

--- a/styles/bootstrap.flatly.css
+++ b/styles/bootstrap.flatly.css
@@ -11,7 +11,10 @@
  * Copyright 2011-2019 Twitter, Inc.
  * Licensed under MIT (https://github.com/twbs/bootstrap/blob/master/LICENSE)
  */
-@import url("https://fonts.googleapis.com/css?family=Lato:400,700,400italic");
+/* iacr.org no longer takes content from off-site. Lato doesn't seem different enough
+ * from other sans-serif fonts to justify loading it locally.
+ * @import url("https://fonts.googleapis.com/css?family=Lato:400,700,400italic");
+*/
 :root {
   --blue: #2C3E50;
   --indigo: #6610f2;


### PR DESCRIPTION
This change is a bit complicated. It combines a few things that we might separate out.

1. The CORS policy is expressed in the html instead of the .htaccess file. This is more efficient and will work with nginx as well as apache.
2. The CORS policy has been changed. It now forbids loading offsite css, which uncovered an offsite font from googleapis.com. I ended up just removing this font because it seems to add nothing to flatly anyway.
3. The progress bar error handling now has a third possible outcome for handling error cases. Unfortunately we don't get any information from crossref because they don't send the CORS header in the case of their 500 error, but we can at least flag server errors in the future.
4. The progress bar now has two colors to indicate the percentage of success. I'm not sure if I like it, and this is a subjective call.