### PR TITLE
Update to schema.

### DIFF
--- a/docs/.htaccess
+++ b/docs/.htaccess
@@ -1,0 +1,1 @@
+Header set Access-Control-Allow-Origin "*"

--- a/docs/program_schema.json
+++ b/docs/program_schema.json
@@ -1,26 +1,39 @@
 {
-  "description": "Schema to describe the program of a multi-track conference. This was originally designed for IACR conferences, but may find other uses.",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Conference Program",
+  "description": "Schema to describe the program of a multi-track conference.",
+  "$id": "https://www.iacr.org/tools/program/docs/program_schema.json",
   "type": "object",
-  "id": "https://www.iacr.org/tools/program/docs/program_schema.json",
   "definitions": {
     "location": {
-      "id": "#definitions/location",
-      "type": "object",
-      "required": ["name"],
-      "properties": {
-        "name": {
+      "$comment": "Object is preferred over string. String version is just name.",
+      "anyOf": [
+        {
+          "deprecated": true,
           "type": "string"
         },
-        "latitude": {
-          "type": "number"
-        },
-        "longitude": {
-          "type": "number"
+        {
+          "type": "object",
+          "required": ["name"],
+          "properties": {
+            "name": {
+              "type": "string"
+            },
+            "latitude": {
+              "type": "number",
+              "minimum": -90,
+              "maximum": 90
+            },
+            "longitude": {
+              "type": "number",
+              "minimum": -180,
+              "maximum": 180
+            }
+          }
         }
-      }
+      ]
     },
     "talks": {
-      "id": "#definitions/talks",
       "type": "array",
       "items": {
         "type": "object",
@@ -84,6 +97,7 @@
       }
     }
   },
+  "required": ["name", "config", "days"],
   "properties": {
     "name": {
       "type": "string"
@@ -92,9 +106,10 @@
       "type": "object",
       "properties": {
         "default_track_locations": {
+          "$comment": "Used in case location is not specified on a session.",
           "type": "array",
           "items": {
-            "$ref": "#definitions/location"
+            "$ref": "#/definitions/location"
           },
           "minItems": 1,
           "maxItems": 2
@@ -110,15 +125,37 @@
         "unassigned_talks": {
           "$comment": "While a program is being constructed, this is used to hold talks before they are scheduled.",
           "type": "array",
+          "minItems": 1,
+          "contains": {
+            "type": "object",
+            "required": ["name", "talks", "id"],
+            "properties": {
+              "name": {
+                "type": "string",
+                "pattern": "Uncategorized"
+              },
+              "id": {
+                "type": "string",
+                "pattern": "^category-0$"
+              },
+              "talks": {
+                "$ref": "#/definitions/talks"
+              }
+            }
+          },
           "items": {
             "type": "object",
-            "required": ["name", "talks"],
+            "required": ["name", "talks", "id"],
             "properties": {
               "name": {
                 "type": "string"
               },
               "talks": {
-                "$ref": "#definitions/talks"
+                "$ref": "#/definitions/talks"
+              },
+              "id": {
+                "type": "string",
+                "pattern": "^category-[0-9]+$"
               }
             }
           }
@@ -176,14 +213,14 @@
                         "type": "string"
                       },
                       "location": {
-                        "$ref": "#definitions/location"
+                        "$ref": "#/definitions/location"
                       },
                       "starttime": {
                         "pattern": "^[0-2]?[0-9]:[0-9]{2}$",
                         "type": "string"
                       },
                       "talks": {
-                        "$ref": "#definitions/talks"
+                        "$ref": "#/definitions/talks"
                       },
                       "session_title": {
                         "type": "string"
@@ -212,6 +249,5 @@
       },
       "type": "array"
     }
-  },
-  "title": "Program"
+  }
 }

--- a/json/basic_1day.json
+++ b/json/basic_1day.json
@@ -5,6 +5,7 @@
     "default_talk_minutes": 25,
     "unassigned_talks": [{
       "name": "Uncategorized",
+      "id": "category-0",
       "talks": []
     }]
   },

--- a/json/basic_2day.json
+++ b/json/basic_2day.json
@@ -5,6 +5,7 @@
     "default_talk_minutes": 25,
     "unassigned_talks": [{
       "name": "Uncategorized",
+      "id": "category-0",
       "talks": []
     }]
   },

--- a/json/basic_3day.json
+++ b/json/basic_3day.json
@@ -5,6 +5,7 @@
     "default_talk_minutes": 25,
     "unassigned_talks": [{
       "name": "Uncategorized",
+      "id": "category-0",
       "talks": []
     }]
   },

--- a/json/crypto_config.json
+++ b/json/crypto_config.json
@@ -5,6 +5,7 @@
     "default_talk_minutes": 25,
     "unassigned_talks": [{
       "name": "Uncategorized",
+      "id": "category-0",
       "talks": []
     }]
   },

--- a/json/dualtrack_5day.json
+++ b/json/dualtrack_5day.json
@@ -1,10 +1,18 @@
 {
   "name": "Dual track, 5 days",
   "config": {
-    "default_track_locations": [],
+    "default_track_locations": [
+      {
+        "name": "Location TBD"
+      },
+      {
+        "name": "Location TBD"
+      }
+    ],
     "default_talk_minutes": 25,
     "unassigned_talks": [{
       "name": "Uncategorized",
+      "id": "category-0",
       "talks": []
     }]
   },

--- a/json/ec_config.json
+++ b/json/ec_config.json
@@ -1,10 +1,14 @@
 {
   "name": "Eurocrypt/Asiacrypt (5 days, dual tracks, banquet)",
   "config": {
-    "default_track_locations": ["Location TBD", "Location TBD"],
+    "default_track_locations": [
+      {"name": "Location TBD"},
+      {"name": "Location TBD"}
+    ],
     "default_talk_minutes": 25,
     "unassigned_talks": [{
       "name": "Uncategorized",
+      "id": "category-0",
       "talks": []
     }]
   },

--- a/json/pkc_config.json
+++ b/json/pkc_config.json
@@ -5,6 +5,7 @@
     "default_talk_minutes": 25,
     "unassigned_talks": [{
       "name": "Uncategorized",
+      "id": "category-0",
       "talks": []
     }]
   },


### PR DESCRIPTION
This brings the schema up to the Draft-07 standard. In the meantime json schema have released version 9. In my mind this causes me to think that json schema people will never rest and maybe we should start trying to keep up.

The major changes are:
1. category now requires an id.
2. category-0 is required.
3. location has now deprecated using a string - it's now an object with optional lat/long.